### PR TITLE
Fix: Menu section anchor isn't scrolling to section [NOID]

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -22,6 +22,11 @@ const Footer: React.FC = () => {
       <Text className="text-center">{t("centeredText")}</Text>
       <div className="social__circles">
         <div className="social__circle">
+          <Link href="https://www.instagram.com/7akedi" target="_blank">
+            <FaInstagram className="icon" />
+          </Link>
+        </div>
+        <div className="social__circle">
           <Link href="https://github.com/viniciustakedi" target="_blank">
             <FaGithubAlt className="icon" />
           </Link>
@@ -32,11 +37,6 @@ const Footer: React.FC = () => {
             target="_blank"
           >
             <FaLinkedin className="icon" />
-          </Link>
-        </div>
-        <div className="social__circle">
-          <Link href="https://www.instagram.com/7akedi" target="_blank">
-            <FaInstagram className="icon" />
           </Link>
         </div>
       </div>

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -31,6 +31,7 @@ const Menu: React.FC = () => {
 
   const [isSwitcherOpen, setIsSwitcherOpen] = React.useState<boolean>(false);
   const switcherRef = React.useRef<HTMLDivElement | null>(null);
+  const switcherMobileRef = React.useRef<HTMLDivElement | null>(null);
 
   const [currentLang, setCurrentLang] = React.useState<LanguagesSupported>(
     LanguagesSupported.en
@@ -60,11 +61,21 @@ const Menu: React.FC = () => {
   React.useEffect(() => {
     const checkIfClickedOutside = (e: MouseEvent) => {
       if (
-      isSwitcherOpen &&
-      switcherRef.current &&
-      !switcherRef.current.contains(e.target as Node)
+        isSwitcherOpen &&
+        switcherRef.current &&
+        !switcherRef.current.contains(e.target as Node) &&
+        !switcherMobileRef.current
       ) {
-      setIsSwitcherOpen(false);
+        setIsSwitcherOpen(false);
+      }
+
+      if (
+        isSwitcherOpen &&
+        switcherMobileRef.current &&
+        !switcherRef.current &&
+        !switcherMobileRef.current.contains(e.target as Node)
+      ) {
+        setIsSwitcherOpen(false);
       }
     };
 
@@ -122,6 +133,7 @@ const Menu: React.FC = () => {
               className="menu__link"
               onClick={(event) => {
                 event.preventDefault();
+                document.querySelector(item.link)?.scrollIntoView({ behavior: "smooth" });
                 handleMenuAction(item.link);
               }}
             >
@@ -137,7 +149,7 @@ const Menu: React.FC = () => {
           >
             <FaLanguage className="icon" />
             {isSwitcherOpen && (
-              <div className="switcher">
+              <div className="switcher" ref={switcherMobileRef}>
                 {languagesMap.map(
                   (e: {
                     value: LanguagesSupported;


### PR DESCRIPTION
## 📝 Description

Fix menu anchor that wasn't redirecting the user to option chosen on menu links.

### 🔧 Changes:
- Changes on menu link props on click.
- Footer circle icons order changed to follow the menu order.
- Added one more ref to mobile language switcher.

---

## 📸 Screenshots (if applicable)

_Not applicable – no visual/UI changes._

---

## ✅ Checklist
 - [X] Menu link anchors fixed
 - [X] No breaking changes introduced

---

## 📎 Related Issues / Tasks

N/A